### PR TITLE
Add file-type aware conversion helper for OCR

### DIFF
--- a/pdf-image-to-text-converter/src/services/ocrService.js
+++ b/pdf-image-to-text-converter/src/services/ocrService.js
@@ -32,3 +32,16 @@ export const convertPdfToText = async (pdfFile) => {
         throw error;
     }
 };
+
+export const convertFileToText = async (file) => {
+    try {
+        if (file.type === 'application/pdf') {
+            return await convertPdfToText(file);
+        } else {
+            return await convertImageToText(file);
+        }
+    } catch (error) {
+        console.error('Error converting file:', error);
+        throw error;
+    }
+};

--- a/src/services/ocrService.js
+++ b/src/services/ocrService.js
@@ -32,3 +32,16 @@ export const convertPdfToText = async (pdfFile) => {
         throw error;
     }
 };
+
+export const convertFileToText = async (file) => {
+    try {
+        if (file.type === 'application/pdf') {
+            return await convertPdfToText(file);
+        } else {
+            return await convertImageToText(file);
+        }
+    } catch (error) {
+        console.error('Error converting file:', error);
+        throw error;
+    }
+};


### PR DESCRIPTION
## Summary
- add `convertFileToText` helper to route PDF and image files to the proper OCR function
- keep existing OCR helpers and export the new one in both apps
- ensure Converter components use the helper with error handling

## Testing
- `CI=true npm test --silent -- --watchAll=false --passWithNoTests`
- `(cd pdf-image-to-text-converter && CI=true npm test --silent -- --watchAll=false --passWithNoTests)`

------
https://chatgpt.com/codex/tasks/task_e_689175bcdbe4832fade3acc97c4a56be