### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+package-lock.json
+build
+pdf-image-to-text-converter
+.git
+.gitignore
+Dockerfile
+.dockerignore
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM node:16-alpine AS build
+WORKDIR /app
+
+# Install dependencies
+COPY package.json ./
+RUN npm install
+
+# Copy source files
+COPY public ./public
+COPY src ./src
+
+# Build the React app
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ pdf-image-to-text-converter
 
 3. Use the file upload feature to select a PDF or image file and convert it to text.
 
+## Docker
+
+To run the application using Docker:
+
+1. Build the image:
+   ```
+   docker build -t pdf-image-to-text-converter .
+   ```
+
+2. Start a container:
+   ```
+   docker run -p 1429:80 pdf-image-to-text-converter
+   ```
+
+3. Open `http://localhost:1429` in your browser to access the application.
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request for any enhancements or bug fixes.


### PR DESCRIPTION
## Summary
- add Dockerfile for building and serving the React app
- add dockerignore and gitignore to keep build artifacts and dependencies out of images and commits
- document Docker usage in README

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689186e12728832fa976e1bcce005d41